### PR TITLE
Allow Thelia projects to properly load the core translations

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -3,8 +3,11 @@
 // Here you can override thelia directories constants.
 // Please see vendor/thelia/core/bootstrap.php
 
-define ("THELIA_ROOT", __DIR__ . DIRECTORY_SEPARATOR);
-define ("THELIA_SETUP_DIRECTORY", __DIR__ . DIRECTORY_SEPARATOR . "local" . DIRECTORY_SEPARATOR . "setup" . DIRECTORY_SEPARATOR);
+define('DS', DIRECTORY_SEPARATOR);
+define ("THELIA_ROOT", __DIR__ . DS);
+define ('THELIA_VENDOR', __DIR__ . DS . 'vendor' . DS);
+define ('THELIA_LIB', THELIA_VENDOR . 'thelia' . DS . 'core' . DS . 'lib' . DS . 'Thelia' . DS);
+define ("THELIA_SETUP_DIRECTORY", __DIR__ . DS . "local" . DS . "setup" . DS);
 
 // --------------------------------------------------
 


### PR DESCRIPTION
Override two newly defined at runtime constants in thelia/thelia#1327. That allows to properly load the core translations.