### PR TITLE
chore: bump frontoffice-modern-template to ~2.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "thelia/thelia-skeleton": "~2.6.0",
     "symfony/flex": "^2.4",
-    "thelia/frontoffice-modern-template": "~2.5.5",
+    "thelia/frontoffice-modern-template": "~2.6.1",
     "thelia/open-api-module": "^2.2",
     "thelia/smarty-redirection-module": "~2.0.0",
     "thelia/choice-filter-module": "~2.1.0",


### PR DESCRIPTION
The ~2.5.5 pin was serving a 2.5.5 front template on 2.6 installs. thelia/frontoffice-modern-template 2.6.1 is now published. thelia/thelia-skeleton ~2.6.0 already covers 2.6.1.