### PR TITLE
fix: create var/translations during install so the first page does not 500

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -92,9 +92,11 @@ if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $dbName)) {
 
 // ── Phase 1: Check permissions ───────────────────────────────────────
 
-// Ensure required directories exist (may be missing after a fresh clone)
+// Ensure required directories exist (may be missing after a fresh clone).
+// var/translations is registered as an AssetMapper path by symfony/ux-translator,
+// which never creates it at boot: without it, the first page answers 500.
 $fs = new Symfony\Component\Filesystem\Filesystem();
-foreach (['var', 'public', 'local/media', 'local/config'] as $dir) {
+foreach (['var', 'public', 'local/media', 'local/config', 'var/translations'] as $dir) {
     $fs->mkdir(THELIA_ROOT.$dir);
 }
 


### PR DESCRIPTION
Mirror of thelia/thelia#3791 — `bin/install` is duplicated in both repositories.

On a fresh `composer create-project thelia/thelia-project`, the first front-office page answers 500: `symfony/ux-translator` registers `%kernel.project_dir%/var/translations` as an AssetMapper path, but only its optional cache warmer creates the directory, and nothing in the install runs it. This adds `var/translations` to the directories `bin/install` already ensures exist. Idempotent, theme-independent, harmless when ux-translator is absent.

Issue: https://github.com/thelia/thelia/issues/3784