### PR TITLE
fix(install): skip the Sass build when no active theme ships Sass sources

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -331,6 +331,14 @@ foreach ([
     'tailwind:build' => 'Building the front-office stylesheet',
     'sass:build' => 'Building the Sass stylesheets',
 ] as $command => $label) {
+    // sass:build compiles the entry files the active theme declares. When none of
+    // the selected themes ships Sass, symfonycasts/sass-bundle keeps its own
+    // default entry (assets/styles/app.scss), a file Thelia does not ship, and the
+    // build fails on a stylesheet nobody asked for.
+    if ('sass:build' === $command && !hasSassSourcesToBuild($themes)) {
+        continue;
+    }
+
     $commands[] = [
         'label' => $label,
         'input' => ['command' => $command],
@@ -425,6 +433,48 @@ function resolveJwtKeyPath(string $envName, string $defaultFileName): string
     }
 
     return str_replace('%kernel.project_dir%/', THELIA_ROOT, $path);
+}
+
+/**
+ * Whether one of the selected themes, or the project itself, ships a Sass entry file.
+ *
+ * A theme built on Sass registers its own entry file with symfonycasts/sass-bundle,
+ * but only while it is the active one: on any run where another theme is selected,
+ * the bundle falls back to its default entry and the build fails on a file that does
+ * not exist. Partials (a leading underscore) are compile-time inputs, never entries.
+ *
+ * @param array<string, string> $selectedThemes
+ */
+function hasSassSourcesToBuild(array $selectedThemes): bool
+{
+    $searchDirectories = [THELIA_ROOT.'assets'];
+
+    foreach ($selectedThemes as $type => $name) {
+        $name = trim($name);
+
+        if ('' !== $name) {
+            $searchDirectories[] = THELIA_TEMPLATE_DIR.$type.DS.$name.DS.'assets';
+        }
+    }
+
+    foreach ($searchDirectories as $directory) {
+        if (!is_dir($directory)) {
+            continue;
+        }
+
+        $finder = (new Symfony\Component\Finder\Finder())
+            ->files()
+            ->in($directory)
+            ->exclude(['vendor', 'node_modules'])
+            ->name('*.scss')
+            ->notName('_*');
+
+        if ($finder->hasResults()) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
Mirror of thelia/thelia#3842: `bin/install` is duplicated here, so the fix has to land in both copies.

`sass:build` was queued on every install. That command belongs to a theme compiling its stylesheet with symfonycasts/sass-bundle — today only the Twig back-office — and the bundle only receives an entry file while that theme is active. On a shop installed with the Smarty back-office, the bundle stays on its own default entry, `assets/styles/app.scss`, which Thelia does not ship, and dart-sass fails on it from the second install on. The build is now queued only when one of the themes being activated, or the project itself, ships a Sass entry file.

The file is byte-identical to the one in thelia/thelia#3842, so `check-bin-install-parity` stays red until that PR is merged. Re-run the job afterwards.
