### PR TITLE
feat: ship the application cache backend variables

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -22,6 +22,18 @@ APP_SECRET=
 DEBUG_TRUSTED_IP=::1,127.0.0.1
 ###< thelia/thelia ###
 
+###> thelia/cache ###
+# Where the application cache is stored. Empty keeps it on the local file
+# system, which is what a single server needs. Point it at a shared cache
+# server to serve one shop from several front ends, for example
+# redis://localhost:6379 or memcached://localhost:11211.
+THELIA_CACHE_DSN=
+# Keys are namespaced with the install path and the environment. Set this only
+# when the same shop is deployed under different paths on machines sharing one
+# cache server. See the application cache page of the documentation.
+#THELIA_CACHE_PREFIX_SEED=
+###< thelia/cache ###
+
 ###> symfony/lock ###
 # Choose one of the stores below
 # postgresql+advisory://db_user:db_password@localhost/db_name


### PR DESCRIPTION
## Summary

- Ships the two application cache variables in `.env.dist`, in a `thelia/cache` block: `THELIA_CACHE_DSN` empty, and `THELIA_CACHE_PREFIX_SEED` commented out.
- A new install therefore keeps the cache on the local file system and behaves as it does today until the hosting fills the data source name. Filled with `redis://localhost:6379` or `memcached://localhost:11211`, every application cache pool moves to that server with no change to the code of the shop.
- Requires the core side, thelia/thelia#3892: without it the variables are read but nothing consumes them.

## Test plan

- [x] `THELIA_CACHE_DSN=` in the shipped file leaves the cache on disk, which is the behaviour a fresh install has today. Verified on the core side with the same block in its own `.env`: front, back office and the API login and token refresh answer 200, and the pools are written under `var/pools/<env>`.
- [x] `THELIA_CACHE_DSN=redis://redis:6379` moves the pools to Redis. Same walk answers 200 and the keys appear under `redis-cli --scan`.
- [x] `THELIA_CACHE_PREFIX_SEED` stays commented out rather than set empty: an empty seed would put every shop of a shared cache server in one keyspace.
